### PR TITLE
Fix malformed description line

### DIFF
--- a/tabbar.el
+++ b/tabbar.el
@@ -1,5 +1,5 @@
 ;; -*-no-byte-compile: t; -*-
-;;; Tabbar.el --- Display a tab bar in the header line
+;;; tabbar.el --- Display a tab bar in the header line
 
 ;; Copyright (C) 2003, 2004, 2005 David Ponce
 


### PR DESCRIPTION
This capitalized char prevented package.el from validating the file, and consequently stopped MELPA from determining a description for the tabbar packages it builds.
