### PR TITLE
Remove unnecessary height attribute from tabbar-separator

### DIFF
--- a/tabbar.el
+++ b/tabbar.el
@@ -617,7 +617,6 @@ current cached copy."
 (defface tabbar-separator
   '((t
      :inherit tabbar-default
-     :height 0.1
      ))
   "Face used for separators between tabs."
   :group 'tabbar)


### PR DESCRIPTION
On my GNU/Linux systems, presence of this 0.1 height causes excessive
use of memory by Emacs.
