### PR TITLE
Check mouse-wheel-mode exists when disable

### DIFF
--- a/tabbar.el
+++ b/tabbar.el
@@ -1623,7 +1623,9 @@ Returns non-nil if the new state is enabled.
   :global t
   :keymap tabbar-mwheel-mode-map
   (when tabbar-mwheel-mode
-    (unless (and mouse-wheel-mode tabbar-mode)
+    (unless (and (boundp 'mouse-wheel-mode)
+                 mouse-wheel-mode
+                 tabbar-mode)
       (tabbar-mwheel-mode -1))))
 
 (defun tabbar-mwheel-follow ()


### PR DESCRIPTION
No more need `mouse-wheel-mode` when mouse-wheel-mode is explicitly disabled like `(tabbar-mwheel-mode nil)`.
