### PR TITLE
Improve compatibility with aquamacs-ask-for-confirmation

### DIFF
--- a/aquamacs-tools.el
+++ b/aquamacs-tools.el
@@ -62,7 +62,7 @@ The return value is the incremented value of PLACE."
   (memq initial-window-system '(mac ns)))
 
 
-(defun aquamacs-ask-for-confirmation (text long &optional yes-button no-button sheet no-cancel)
+(defun aquamacs-ask-for-confirmation (text long &optional yes-button no-button sheet)
     (let ((f (window-frame (minibuffer-window))))
       (make-frame-visible f)
       (raise-frame f)			; make sure frame is visible
@@ -88,11 +88,8 @@ The return value is the incremented value of PLACE."
 	(let ((ret (x-popup-dialog (or sheet (if (mouse-event-p last-command-event) last-command-event)
 				        `(mouse-1      (,(selected-window) 100 (0 . 50) -1)))
 				    (list text
-					  `((,(or yes-button "Yes") . ?\r) . t) ; use \r instead of y until we have multi-keyEquivs
-					  (if no-cancel 'no-cancel 'cancel)
-					  `((,(or no-button "No") . ?n) . nil)))))
-	  (if (eq ret 'cancel)
-	      (keyboard-quit))
+					  `(,(or yes-button "Yes") . t)
+					  `(,(or no-button "No") . nil)))))
 	  ret))))
 
 


### PR DESCRIPTION
According to https://github.com/davidswelt/aquamacs-emacs/commit/2e266a632ed6a3282519fcff291a8ad5ad1b0a16 , aquamacs's `x-popup-dialog` allows CONTENTS's ITEM's car to be a cons to specify a key while vanilla emacs can't.
According to https://github.com/davidswelt/aquamacs-emacs/commit/2169d5e4d3c7988cc1d5f574016cef100bdb8b52#diff-1df04a715f06f2f2b8a0d4f1f2f3e701R2427 , aquamacs's `x-popup-dialog` allows CONTENTS's ITEM to be `'cancel` or `'no-cancel` while vanilla emacs can't.