### PR TITLE
tabbar-buffer-update-groups was not receiving results from tabbar-buffer-list-function

### DIFF
--- a/tabbar.el
+++ b/tabbar.el
@@ -1762,7 +1762,7 @@ Return the the first group where the current buffer is."
                               (funcall tabbar-buffer-groups-function)
                             '("Common")))))
               (and tabbar-buffer-list-function
-                   (funcall tabbar-buffer-list-function)))
+                   (tabbar-buffer-list)))
              #'(lambda (e1 e2)
                  (string-lessp (nth 1 e1) (nth 1 e2))))))
     ;; If the cache has changed, update the tab sets.


### PR DESCRIPTION
I tried to hide some tabs with "*" from my tabbar.
After some google search, I found out that overriding "tabbar-buffer-list" does the work. 
So I have added 

```
(defun dotspacemacs/user-config ()
  (defun tabbar-buffer-list ()
    (delq nil
          (mapcar #'(lambda (b)
                      (cond
                       ((eq (current-buffer) b) b)
                       ((char-equal ?\  (aref (buffer-name b) 0)) nil)
                       ((equal "buffer *scratch*" (buffer-name b)) b)
                       ((buffer-live-p b) b)))
                   (buffer-list))))
```

to my .spacemacs file. 

However, strangely, my tabbar kept showing me some buffers with "*".

After the fix. It started working.
I have no experience of Lisp, so I am not sure what I am doing, but I can say it started working.
Would you take look at this? 

Editor : Spacemacs 0.200.13 (Emacs 25.3.2)
OS : Mint linux 18.3